### PR TITLE
fix: allow fuseki to receive and handle signals properly (INFRA-517)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV LANG C.UTF-8
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-       bash curl ca-certificates findutils coreutils pwgen procps \
+       tini bash curl ca-certificates findutils coreutils pwgen procps \
     ; \
     rm -rf /var/lib/apt/lists/*
 
@@ -88,5 +88,5 @@ HEALTHCHECK --interval=15s --timeout=3s --retries=3 --start-period=30s \
 # Where we start our server from
 WORKDIR $FUSEKI_HOME
 EXPOSE 3030
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["/jena-fuseki/fuseki-server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -70,11 +70,4 @@ if [ -n "$REBUILD_INDEX_OF_DATASET" ] ; then
 fi
 
 # Start Fueski server
-exec "$@" &
-
-# Wait until server is up
-while [[ $(curl -I http://localhost:3030 2>/dev/null | head -n 1 | cut -d$' ' -f2) != '200' ]]; do
-  sleep 1s
-done
-
-wait
+exec "$@"


### PR DESCRIPTION
Fuseki couldn't receive nor handle signals properly because the process was running in the background and the shell does not forward signals. Now Fuseki replaces the shell process entirely so that it receives all signals.