### PR TITLE
chore: Update Java version to 21 (DEV-3540)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 # Credits: Mainly copied from https://github.com/stain/jena-docker
 
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 ENV LANG C.UTF-8
 RUN set -eux; \


### PR DESCRIPTION
As confirmed by the mailing list: Jena tests against Java 21 already, so that should be ok.