### PR TITLE
chore(dockerfile): don't report healthy while text indexer is still running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,7 @@ RUN chmod 755 /docker-entrypoint.sh
 # responding to a ping or whether text indexer is
 # running
 HEALTHCHECK --interval=15s --timeout=3s --retries=3 --start-period=30s \
-  CMD curl -sS --fail 'http://localhost:3030/$/ping' || \
-      pgrep -f "jena.textindexer" >/dev/null || \
-      exit 1
+  CMD curl -sS --fail 'http://localhost:3030/$/ping' || exit 1
 
 # Where we start our server from
 WORKDIR $FUSEKI_HOME


### PR DESCRIPTION
Previously we changed the healthcheck to report healthy while the text indexer is running. However, this now sometimes causes issues because when the container is healthy it is assumed that the DB is ready and reachable. We now no longer report healthy during text index rebuilding and will instead increase the container `start-period` where necessary.