### PR TITLE
feat(config): bake dsp-repo configuration into fuseki image (INFRA-867)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.vscode
+/.data

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ VOLUME /fuseki
 ENV FUSEKI_BASE /fuseki
 ENV INDEX_BASE $FUSEKI_BASE/lucene
 
-
 # Installation folder
 ENV FUSEKI_HOME /jena-fuseki
 
@@ -70,6 +69,11 @@ RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki
 # shiro.ini contains a default password. To override, start
 # container with ADMIN_PASSWORD environment variable set
 COPY shiro.ini $FUSEKI_HOME/shiro.ini
+
+# Create built-in database config
+COPY dsp-repo.ttl $FUSEKI_BASE/configuration/dsp-repo.ttl
+
+# Create entrypoint
 COPY docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN  bash -c '[ "$($FUSEKI_HOME/fuseki-server --version)" == "Apache Jena Fuseki
 COPY shiro.ini $FUSEKI_HOME/shiro.ini
 
 # Create built-in database config
-COPY dsp-repo.ttl $FUSEKI_BASE/configuration/dsp-repo.ttl
+COPY dsp-repo.ttl $FUSEKI_HOME/dsp-repo.ttl
 
 # Create entrypoint
 COPY docker-entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ dasch-swiss/apache-jena-fuseki
 
 Note that although these Docker images are based on the official Apache Jena Fuseki releases and do not alter them in any way, they do not constitute official releases from the Apache Software Foundation.
 
+As of version `5.5.0-1`, the database comes with a pre-configured TDB2 dataset called `dsp-repo` and a Lucene text index. For more details, see the [dsp-repo.ttl](dsp-repo.ttl) dataset configuration file.
+
 ## Dockerfile overview
 The Dockerfile uses the official openjdk:11-jre-slim-buster base image, which is based on the [debian](https://hub.docker.com/_/debian/):buster-slim image; this clocks in at about 69 MB.
 
@@ -19,7 +21,7 @@ To minimize layer size, there's a single RUN with curl, sha512sum, tar zxf and m
 
 Some files from the Apache Jena distributions are stripped, e.g., fuseki.war file.
 
-The Fuseki image includes some helper scripts to do tdb loading using fuseki-server.jar. In addition Fuseki has a [docker-entrypoint.sh](https://github.com/dasch-swiss/docker-apache-jena-fuseki/blob/main/docker-entrypoint.sh) that populates shiro.ini with the password provided as `-e ADMIN_PASSWORD` to Docker, or with a new randomly generated password that is printed the first time.  
+The Fuseki image includes some helper scripts to do tdb loading using fuseki-server.jar. In addition Fuseki has a [docker-entrypoint.sh](https://github.com/dasch-swiss/docker-apache-jena-fuseki/blob/main/docker-entrypoint.sh) that populates [shiro.ini](shiro.ini) with the password provided as `-e ADMIN_PASSWORD` to Docker, or with a new randomly generated password that is printed the first time. The [dsp-repo.ttl](dsp-repo.ttl) dataset configuration is used to set up the default `dsp-repo` dataset through the `$FUSEKI_BASE/configuration/` [directory mechanism](https://jena.apache.org/documentation/fuseki2/fuseki-configuration.html).    
 There is also a `REBUILD_INDEX_OF_DATASET` environment variable that makes the container rebuild Fuseki's built-in Lucene index before starting the database normally. To enable this, the value of this variable must be set to the name of the dataset whose index should be rebuilt. Alternatively the `REBUILD_INDEX_MARKER_FILE` variable can be set to the path of a marker file inside the container containing the aforementioned dataset name. The marker file is deleted after a successful rebuild. The index data is assumed to be located at $INDEX_BASE/<dataset> (default: /fuseki/lucene/<dataset>).
 
 ## Releasing

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,12 @@ if [ -n "$ADMIN_PASSWORD" ] ; then
   sed -i "s/^admin=.*/admin=$ADMIN_PASSWORD/" "$FUSEKI_BASE/shiro.ini"
 fi
 
+# copy dsp-repo.ttl
+if [ ! -e "$FUSEKI_BASE/configuration/dsp-repo.ttl" ]; then
+  mkdir -p "$FUSEKI_BASE/configuration"
+  cp "$FUSEKI_HOME/dsp-repo.ttl" "$FUSEKI_BASE/configuration/dsp-repo.ttl"
+fi
+
 # Check if index rebuild marker file exists
 if [ ! -n "$REBUILD_INDEX_OF_DATASET" ] && [ -f "$REBUILD_INDEX_MARKER_FILE" ] ; then
   info "Detected index rebuild marker file ${REBUILD_INDEX_MARKER_FILE}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,5 +69,21 @@ if [ -n "$REBUILD_INDEX_OF_DATASET" ] ; then
   fi
 fi
 
+# Change JVM_ARGS to address warnings in Java 21+:
+#   WARNING: A restricted method in java.lang.foreign.Linker has been called
+#   WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
+#   WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module
+#   WARN  VectorizationProvider :: Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.
+# See also:
+#   https://github.com/apache/jena/issues/2533
+#   https://github.com/apache/jena/pull/2782
+#   https://github.com/apache/jena/blob/c14193e528a86e97f0ab86cf3827d6ba9ac60296/jena-text/pom.xml#L32-L39
+if [ -z "$JVM_ARGS" ]; then
+  # this is the default if not set, see /jena-fuseki/fuseki-server wrapper
+  JVM_ARGS="-Xmx4G"
+fi
+export JVM_ARGS="${JVM_ARGS} --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector"
+info "JVM_ARGS: $JVM_ARGS"
+
 # Start Fueski server
 exec "$@"

--- a/dsp-repo.ttl
+++ b/dsp-repo.ttl
@@ -1,0 +1,52 @@
+@prefix :           <http://base/#> .
+@prefix fuseki:     <http://jena.apache.org/fuseki#> .
+@prefix ja:         <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix tdb2:       <http://jena.apache.org/2016/tdb#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix text:       <http://jena.apache.org/text#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+
+:service_tdb_all        a                                   fuseki:Service ;
+                        rdfs:label                          "TDB2 dsp-repo" ;
+                        fuseki:dataset                      :text_dataset ;
+                        fuseki:name                         "dsp-repo" ;
+                        fuseki:serviceQuery                 "query" , "sparql" ;
+                        fuseki:serviceReadGraphStore        "get" ;
+                        fuseki:serviceReadWriteGraphStore   "data" ;
+                        fuseki:serviceUpdate                "update" ;
+                        fuseki:serviceUpload                "upload" .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset           rdf:type                            text:TextDataset ;
+                        text:dataset                        :tdb_dataset_readwrite ;
+                        text:index                          :indexLucene .
+
+# A TDB datset used for RDF storage
+:tdb_dataset_readwrite  a                                   tdb2:DatasetTDB2 ;
+                        tdb2:unionDefaultGraph              true ;
+                        tdb2:location                       "/fuseki/databases/dsp-repo" .
+
+# Text index description
+:indexLucene            a                                   text:TextIndexLucene ;
+                        text:directory                      "/fuseki/lucene/dsp-repo" ;
+                        text:entityMap                      :entMap ;
+                        text:analyzer                       [ a text:ConfigurableAnalyzer ;
+                                                               text:tokenizer text:WhitespaceTokenizer ;
+                                                               text:filters ( text:ASCIIFoldingFilter text:LowerCaseFilter)
+                                                            ] .
+
+# Mapping in the index
+# URI stored in field "uri"
+# knora-base:valueHasString is mapped to field "text"
+:entMap                 a                                   text:EntityMap ;
+                        text:entityField                    "uri" ;
+                        text:defaultField                   "text" ;
+                        text:uidField                       "uid" ;
+                        text:map                            (
+                                                                [ text:field  "text" ;  text:predicate  rdfs:label ]
+                                                                [ text:field  "text" ;  text:predicate  knora-base:valueHasString ]
+                                                                [ text:field  "text" ;  text:predicate  knora-base:valueHasComment ]
+                                                            ) .


### PR DESCRIPTION
Also addressed a couple of warnings, see comment in docker-entrypoint.sh.

The dsp-repo.ttl is from https://github.com/dasch-swiss/ops-deploy/blob/main/roles/dsp-deploy/templates/db-ops/fuseki_repository_config.ttl.j2 with the `fuseki:Server` node removed and DSP_DB_REPOSITORY=dsp-repo.